### PR TITLE
feat(nvim): Add gitsigns/illuminate/autopairs/todo-comments/which-key

### DIFF
--- a/app/NeoVim.2026/lua/plugins/autopairs.lua
+++ b/app/NeoVim.2026/lua/plugins/autopairs.lua
@@ -1,0 +1,5 @@
+return {
+  'windwp/nvim-autopairs',
+  event = 'InsertEnter',
+  opts = {},
+}

--- a/app/NeoVim.2026/lua/plugins/gitsigns.lua
+++ b/app/NeoVim.2026/lua/plugins/gitsigns.lua
@@ -1,0 +1,7 @@
+return {
+  'lewis6991/gitsigns.nvim',
+  event = { 'BufReadPre', 'BufNewFile' },
+  opts = {
+    current_line_blame = true,
+  },
+}

--- a/app/NeoVim.2026/lua/plugins/illuminate.lua
+++ b/app/NeoVim.2026/lua/plugins/illuminate.lua
@@ -1,0 +1,11 @@
+return {
+  'RRethy/vim-illuminate',
+  event = { 'BufReadPost', 'BufNewFile' },
+  opts = {
+    providers = { 'lsp', 'treesitter', 'regex' },
+    delay = 200,
+  },
+  config = function(_, opts)
+    require('illuminate').configure(opts)
+  end,
+}

--- a/app/NeoVim.2026/lua/plugins/lualine.lua
+++ b/app/NeoVim.2026/lua/plugins/lualine.lua
@@ -1,7 +1,9 @@
 return {
   'nvim-lualine/lualine.nvim',
   dependencies = { 'nvim-tree/nvim-web-devicons' },
-  config = function()
-    require('lualine').setup({})
-  end,
+  opts = {
+    sections = {
+      lualine_b = { 'branch', 'diff', 'diagnostics' },
+    },
+  },
 }

--- a/app/NeoVim.2026/lua/plugins/todo-comments.lua
+++ b/app/NeoVim.2026/lua/plugins/todo-comments.lua
@@ -1,0 +1,9 @@
+return {
+  'folke/todo-comments.nvim',
+  dependencies = { 'nvim-lua/plenary.nvim' },
+  event = { 'BufReadPost', 'BufNewFile' },
+  opts = {},
+  keys = {
+    { '<leader>ft', '<cmd>TodoTelescope<cr>', desc = 'Find Todos' },
+  },
+}

--- a/app/NeoVim.2026/lua/plugins/which-key.lua
+++ b/app/NeoVim.2026/lua/plugins/which-key.lua
@@ -1,0 +1,13 @@
+return {
+  'folke/which-key.nvim',
+  event = 'VeryLazy',
+  opts = {},
+  config = function(_, opts)
+    local wk = require('which-key')
+    wk.setup(opts)
+    wk.add({
+      { '<leader>f', group = 'Find' },
+      { '<leader>g', group = 'Git' },
+    })
+  end,
+}


### PR DESCRIPTION
## Summary

- `gitsigns.nvim`: 行番号エリアに git 差分マーク表示 + カーソル行の inline blame
- `vim-illuminate`: カーソル下シンボルのハイライト（LSP → Treesitter → regex の優先順でフォールバック）
- `nvim-autopairs`: 括弧・引用符の自動補完（blink.cmp の `auto_brackets` と役割分担で共存）
- `todo-comments.nvim`: `TODO:` / `FIXME:` 等のハイライト + `<leader>ft` で TodoTelescope 連携
- `which-key.nvim`: キーバインドポップアップ（`<leader>f` / `<leader>g` グループ登録済み）
- `lualine.nvim`: `lualine_b` に `branch` / `diff`（gitsigns）/ `diagnostics`（LSP）を追加

## Test plan

- [x] `with-env { NVIM_APPNAME: "NeoVim.2026", XDG_CONFIG_HOME: '<worktree>/app' } { nvim }` で起動確認
- [x] `:Lazy` で 5 プラグインがすべて Installed になっていることを確認
- [x] git 管理下のファイルを開き、行番号エリアに差分マーク・blame が表示されることを確認
- [x] lualine にブランチ名・差分カウント・診断カウントが表示されることを確認
- [x] `TODO:` コメントがハイライトされ、`<leader>ft` で Telescope 一覧が開くことを確認
- [x] 括弧を入力すると自動で閉じることを確認
- [x] カーソル下の識別子と同一シンボルがハイライトされることを確認
- [ ] `<leader>` 入力後にポップアップが表示され、`f` / `g` グループが見えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)