### PR TITLE
feat(nvim): Add NeoTree source tabs and lualine buffer tabline

### DIFF
--- a/app/NeoVim.2026/lua/plugins/lualine.lua
+++ b/app/NeoVim.2026/lua/plugins/lualine.lua
@@ -5,5 +5,8 @@ return {
     sections = {
       lualine_b = { 'branch', 'diff', 'diagnostics' },
     },
+    tabline = {
+      lualine_a = { 'buffers' },
+    },
   },
 }

--- a/app/NeoVim.2026/lua/plugins/neo-tree.lua
+++ b/app/NeoVim.2026/lua/plugins/neo-tree.lua
@@ -8,6 +8,11 @@ return {
     'nvim-tree/nvim-web-devicons', -- optional, but recommended
   },
   opts = {
+    sources = { 'filesystem', 'buffers', 'git_status' },
+    source_selector = {
+      winbar = true,
+      statusline = false,
+    },
     filesystem = {
       filtered_items = {
         hide_dotfiles = false,


### PR DESCRIPTION
## Summary

- `neo-tree.nvim`: `sources` に `filesystem` / `buffers` / `git_status` を追加し、`source_selector.winbar = true` でウィンドウ上部にソース切り替えタブを表示
- `lualine.nvim`: `tabline.lualine_a` に `buffers` コンポーネントを追加し、エディタ上部に開いているファイルのタブ一覧を表示

いずれも新規プラグインの追加なし・既存プラグインの設定追加のみで実現。

## Test plan

- [x] `with-env { NVIM_APPNAME: "NeoVim.2026", XDG_CONFIG_HOME: '<worktree>/app' } { nvim }` で起動確認
- [x] `<leader>e` で NeoTree を開き、ウィンドウ上部に `Files` / `Buffers` / `Git` の3タブが表示されることを確認
- [x] タブを切り替えて Buffers ではバッファ一覧、Git では差分ファイル一覧が表示されることを確認
- [x] エディタ上部に開いているバッファのタブ一覧が表示されることを確認
- [x] ファイルを編集して未保存状態にし、バッファタブに変更インジケーターが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)